### PR TITLE
Update Haml template to handle skos properties.

### DIFF
--- a/ns/Rakefile
+++ b/ns/Rakefile
@@ -1,10 +1,19 @@
+VOCABS= %w(crypto list log math string time)
+
 desc 'Default: build HTML versions of namespace documents'
 task default: :html
 
+desc 'Remove generated files'
+task :clean do
+  VOCABS.each do |v|
+    %x(rm -f #{v}.html)
+  end
+end
+
 desc "Build HTML versions of namespace documents"
-task html: %w(crypto list log math string time).map {|ns| "#{ns}.html"}
+task html: [:clean] + VOCABS.map {|ns| "#{ns}.html"}
 
 rule ".html" => %w{.n3} do |t|
   puts "build #{t.name}"
-  %x{ruby mk_vocab.rb #{t.source}}
+  %x{ruby mk_vocab #{t.source}}
 end

--- a/ns/crypto.html
+++ b/ns/crypto.html
@@ -23,6 +23,10 @@
   }
   table.rdfs-definition td {vertical-align: top;}
   .bold {font-weight: bold;}
+  .note, .historyNote, .editorialNote {
+    margin-left: 2em;
+    font-style: italic;
+  }
 </style>
 </head>
 <body>
@@ -39,15 +43,34 @@ in <a href="http://freshmeat.sourceforge.net/projects/mxcrypto">mxCrypto</a>.</p
 <p>The vocabulary is published by the <a href="https://www.w3.org/community/n3-dev/">W3C Notation-3 Community Group</a>.</p>
 
 </div>
+<div class='historyNote'>
+<h2>
+Historical Note
+</h2>
+<p>Schema for crypto built-in functions in cwm. </p>
+
+<p>These are terms drawn to match the available functions
+in mxCrypto. See:
+http://www.amk.ca/python/writing/pycrypt/  for the manual and
+http://www.amk.ca/python/code/crypto.html  for the code.</p>
+
+<p>I am not sure whether in the domain and range functions we should
+distinguish strings one can present to a person from crypto binary.
+Might be useful for driving the UI and/or serialization using base64 etc.</p>
+
+<p>Beware that the simplicity of use of some of these properties belies
+the knowledge o fcrypography that one needs to make a secure system</p>
+
+</div>
 <strong>
 See Also:
 </strong>
 <ul></ul>
 <li>
-<a href='http://www.amk.ca/python/code/crypto.html'>http://www.amk.ca/python/code/crypto.html</a>
+<a href='http://www.amk.ca/python/writing/pycrypt/'>http://www.amk.ca/python/writing/pycrypt/</a>
 </li>
 <li>
-<a href='http://www.amk.ca/python/writing/pycrypt/'>http://www.amk.ca/python/writing/pycrypt/</a>
+<a href='http://www.amk.ca/python/code/crypto.html'>http://www.amk.ca/python/code/crypto.html</a>
 </li>
 <section>
 <h2>Vocabulary Terms</h2>
@@ -63,10 +86,18 @@ See Also:
 <p>The object is a MD5 hash of the subject.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>rdfs:Literal</dd>
+<dd class='domain'>
+rdfs:Literal
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:string</dd>
+<dd class='range'>
+xsd:string
+</dd>
 </dl>
 </dd>
 <dt id='cr_sha'>
@@ -79,9 +110,13 @@ See Also:
 
 <dl class='annotations'>
 <dt>rdfs:domain</dt>
-<dd>rdfs:Literal</dd>
+<dd class='domain'>
+rdfs:Literal
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:string</dd>
+<dd class='range'>
+xsd:string
+</dd>
 </dl>
 </dd>
 <dt id='cr_sha256'>
@@ -94,9 +129,13 @@ See Also:
 
 <dl class='annotations'>
 <dt>rdfs:domain</dt>
-<dd>rdfs:Literal</dd>
+<dd class='domain'>
+rdfs:Literal
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:string</dd>
+<dd class='range'>
+xsd:string
+</dd>
 </dl>
 </dd>
 <dt id='cr_sha512'>
@@ -109,9 +148,13 @@ See Also:
 
 <dl class='annotations'>
 <dt>rdfs:domain</dt>
-<dd>rdfs:Literal</dd>
+<dd class='domain'>
+rdfs:Literal
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:string</dd>
+<dd class='range'>
+xsd:string
+</dd>
 </dl>
 </dd>
 </dl>

--- a/ns/list.html
+++ b/ns/list.html
@@ -23,6 +23,10 @@
   }
   table.rdfs-definition td {vertical-align: top;}
   .bold {font-weight: bold;}
+  .note, .historyNote, .editorialNote {
+    margin-left: 2em;
+    font-style: italic;
+  }
 </style>
 </head>
 <body>
@@ -36,6 +40,15 @@
 <p>This is an ontology for computable list functions.</p>
 
 <p>The vocabulary is published by the <a href="https://www.w3.org/community/n3-dev/">W3C Notation-3 Community Group</a>.</p>
+
+</div>
+<div class='historyNote'>
+<h2>
+Historical Note
+</h2>
+<p>n3 definition of some list functions</p>
+
+<p>$Id: list.n3,v 1.3 2010-03-26 20:41:54 timbl Exp $</p>
 
 </div>
 <section>
@@ -55,8 +68,14 @@ eg  ( (1 2) (3 4) ) list:append (1 2 3 4).
 The object can be calculated as a function of the subject.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre>( (1 2) (3 4) ) list:append (1 2 3 4).</pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:List</dd>
+<dd class='domain'>
+log:List
+</dd>
 </dl>
 </dd>
 <dt id='list_first'>
@@ -69,10 +88,18 @@ The object can be calculated as a function of the subject.</p>
 The object can be calculated as a function of the list.</p>
 
 <dl class='annotations'>
-<dt>rdfs:domain</dt>
-<dd>log:List</dd>
 <dt>vs:term_status</dt>
-<dd>unstable</dd>
+<dd class='term_status'>
+unstable
+</dd>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>rdfs:domain</dt>
+<dd class='domain'>
+log:List
+</dd>
 </dl>
 </dd>
 <dt id='list_in'>
@@ -85,7 +112,9 @@ The object can be calculated as a function of the list.</p>
 
 <dl class='annotations'>
 <dt>rdfs:range</dt>
-<dd>log:List</dd>
+<dd class='range'>
+log:List
+</dd>
 </dl>
 </dd>
 <dt id='list_last'>
@@ -98,8 +127,14 @@ The object can be calculated as a function of the list.</p>
 The object can be calculated as a function of the list.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:List</dd>
+<dd class='domain'>
+log:List
+</dd>
 </dl>
 </dd>
 <dt id='list_length'>
@@ -112,12 +147,18 @@ The object can be calculated as a function of the list.</p>
 The object can be calculated as a function of the list.</p>
 
 <dl class='annotations'>
-<dt>rdfs:domain</dt>
-<dd>log:List</dd>
-<dt>rdfs:range</dt>
-<dd>xsd:integer</dd>
 <dt>vs:term_status</dt>
-<dd>unstable</dd>
+<dd class='term_status'>
+unstable
+</dd>
+<dt>rdfs:domain</dt>
+<dd class='domain'>
+log:List
+</dd>
+<dt>rdfs:range</dt>
+<dd class='range'>
+xsd:integer
+</dd>
 </dl>
 </dd>
 <dt id='list_member'>
@@ -129,8 +170,14 @@ The object can be calculated as a function of the list.</p>
 <p>Iff the subject is a list and the object is in that list, then this is true.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:List</dd>
+<dd class='domain'>
+log:List
+</dd>
 </dl>
 </dd>
 <dt id='list_memberAt'>
@@ -151,24 +198,32 @@ and if that element and <code>$a_m</code> can unify.</p>
 <code>$a_i</code> or <code>$a_m</code> (or both) must be bound.</p>
 
 <p>Note that if <code>$a_i</code> is a variable, this builtin may bind it to more than one value
-(e.g. <code>((“A” “B” “A”) ?i) list:memberAt "A"</code>).</p>
+(e.g. <code>((“A” “B” “A”) ?i) list:memberAt &quot;A&quot;</code>).</p>
 
 <p><strong>literal domains</strong>:</p>
 
 <ul>
-  <li><code>$a_1 .. $a_n</code>, <code>$a_m</code>: unconstrained</li>
-  <li><code>$a_i</code>: <code>xs:decimal</code>, <code>xs:float</code>, <code>xs:double</code> within the value space of <code>xs:integer</code>
+<li><code>$a_1 .. $a_n</code>, <code>$a_m</code>: unconstrained</li>
+<li><code>$a_i</code>: <code>xs:decimal</code>, <code>xs:float</code>, <code>xs:double</code> within the value space of <code>xs:integer</code>
 (see also note on type promotion and substitution).
-I.e., in case the double/float/decimal's literal's value is within the value space of integers,
+I.e., in case the double/float/decimal&#39;s literal&#39;s value is within the value space of integers,
 the literal will match the domain.
 In case of a negative integer, the index will count backwards from the length of the list.</li>
 </ul>
 
 <dl class='annotations'>
-<dt>rdfs:domain</dt>
-<dd>log:List</dd>
 <dt>vs:term_status</dt>
-<dd>unstable</dd>
+<dd class='term_status'>
+unstable
+</dd>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>rdfs:domain</dt>
+<dd class='domain'>
+log:List
+</dd>
 </dl>
 </dd>
 <dt id='list_remove'>
@@ -184,12 +239,22 @@ eg ( (1 2 3 4) (2 3) ) list:remove (1 4).
 The object can be calculated as a function of the subject.</p>
 
 <dl class='annotations'>
-<dt>rdfs:domain</dt>
-<dd>log:List</dd>
-<dt>rdfs:range</dt>
-<dd>log:List</dd>
 <dt>vs:term_status</dt>
-<dd>unstable</dd>
+<dd class='term_status'>
+unstable
+</dd>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre>( (1 2 3 4) (2 3) ) list:remove (1 4)</pre>
+</dd>
+<dt>rdfs:domain</dt>
+<dd class='domain'>
+log:List
+</dd>
+<dt>rdfs:range</dt>
+<dd class='range'>
+log:List
+</dd>
 </dl>
 </dd>
 </dl>

--- a/ns/log.html
+++ b/ns/log.html
@@ -23,6 +23,10 @@
   }
   table.rdfs-definition td {vertical-align: top;}
   .bold {font-weight: bold;}
+  .note, .historyNote, .editorialNote {
+    margin-left: 2em;
+    font-style: italic;
+  }
 </style>
 </head>
 <body>
@@ -33,13 +37,28 @@
 </p>
 <h1>n3 definition of some Semantic Web terms</h1>
 <div>
-<p>These raise the level above RDF's pure relational data,
-and Web Ontology's ontological level, to allow rules to be expressed
+<p>These raise the level above RDF&#39;s pure relational data,
+and Web Ontology&#39;s ontological level, to allow rules to be expressed
 and inference done. They connect the inference to the web,
 allowing data to be fetched from resources elsewhere, and remote
 servers to be queried.</p>
 
 <p>The vocabulary is published by the <a href="https://www.w3.org/community/n3-dev/">W3C Notation-3 Community Group</a>.</p>
+
+</div>
+<div class='historyNote'>
+<h2>
+Historical Note
+</h2>
+<p>n3 definition of some Semantic Web terms</p>
+
+<p>These raise the level above RDF&#39;s pure relational data,
+and Web Ontology&#39;s ontological level, to allow rules to be expressed
+and inference done. They connect the inference to the web,
+allowing data to be fetched from resources elsewhere, and remote
+servers to be queried.</p>
+
+<p>$Id: log.n3,v 1.25 2010-03-26 20:35:14 timbl Exp $</p>
 
 </div>
 <section>
@@ -54,7 +73,7 @@ servers to be queried.</p>
 </dt>
 <dd>
 <p>Any statement mentioning anything in this class
-is considered boring and purged by the cwm –purge option.
+is considered boring and purged by the cwm --purge option.
 This is a convenience, and does not have any value when published as a
 general fact on the web.</p>
 
@@ -69,7 +88,9 @@ general fact on the web.</p>
 
 <dl class='annotations'>
 <dt>rdfs:subClassOf</dt>
-<dd>log:Type</dd>
+<dd class='subClassOf'>
+log:Type
+</dd>
 </dl>
 </dd>
 <dt id='log_List'>
@@ -82,7 +103,9 @@ general fact on the web.</p>
 
 <dl class='annotations'>
 <dt>rdfs:subClassOf</dt>
-<dd>log:Type, rdf:List</dd>
+<dd class='subClassOf'>
+log:Type, rdf:List
+</dd>
 </dl>
 </dd>
 <dt id='log_N3Document'>
@@ -108,7 +131,9 @@ of any other identifiers used in the document.</p>
 
 <dl class='annotations'>
 <dt>rdfs:subClassOf</dt>
-<dd>log:Type</dd>
+<dd class='subClassOf'>
+log:Type
+</dd>
 </dl>
 </dd>
 <dt id='log_String'>
@@ -121,7 +146,9 @@ of any other identifiers used in the document.</p>
 
 <dl class='annotations'>
 <dt>rdfs:subClassOf</dt>
-<dd>log:Type, rdfs:Literal</dd>
+<dd class='subClassOf'>
+log:Type, rdfs:Literal
+</dd>
 </dl>
 </dd>
 <dt id='log_Truth'>
@@ -132,6 +159,13 @@ of any other identifiers used in the document.</p>
 <dd>
 <p>Something which is true: believe it as you would believe this.</p>
 
+<dl class='annotations'>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>Understood natively by cwm in that it will execute rules in a formula declared a Truth within a formula it is already taking rules from.</p>
+
+</dd>
+</dl>
 </dd>
 <dt id='log_Type'>
 <strong>log:Type</strong>
@@ -143,7 +177,9 @@ of any other identifiers used in the document.</p>
 
 <dl class='annotations'>
 <dt>vs:term_status</dt>
-<dd>unstable</dd>
+<dd class='term_status'>
+unstable
+</dd>
 </dl>
 </dd>
 </dl>
@@ -161,7 +197,9 @@ of any other identifiers used in the document.</p>
 
 <dl class='annotations'>
 <dt>vs:term_status</dt>
-<dd>unstable</dd>
+<dd class='term_status'>
+unstable
+</dd>
 </dl>
 </dd>
 <dt id='log_conclusion'>
@@ -177,10 +215,26 @@ drawn from the subject formula, by successively applying any
 rules it contains to the data it contains.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>This is equivalent to
+cwm&#39;s &quot;--think&quot; command line function.  It does use built-ins, so
+it may for example indirectly invoke other documents, validate
+signatures, etc.</p>
+
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:Formula</dd>
+<dd class='domain'>
+log:Formula
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:Formula</dd>
+<dd class='range'>
+log:Formula
+</dd>
 </dl>
 </dd>
 <dt id='log_conjunction'>
@@ -196,10 +250,23 @@ The object, which can be generated, is a formula containing a copy
 of each of the formulae in the list on the left.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>A cwm built-in function.</p>
+
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:List</dd>
+<dd class='domain'>
+log:List
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:Formula</dd>
+<dd class='range'>
+log:Formula
+</dd>
 </dl>
 </dd>
 <dt id='log_content'>
@@ -211,10 +278,28 @@ of each of the formulae in the list on the left.</p>
 <p>This connects a document and a string that represents it.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:note</dt>
+<dd class='note'>
+<p>Note that the content-type of the information is not given and so must be known or guessed.</p>
+
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>(Cwm knows how to go get a document in order to evaluate this.)</p>
+
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:N3Document</dd>
+<dd class='domain'>
+log:N3Document
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='log_definitiveDocument'>
@@ -228,12 +313,30 @@ any statement X P Y is true iff the semantics of document D
 include that statement.</p>
 
 <dl class='annotations'>
-<dt>rdfs:domain</dt>
-<dd>rdf:Property</dd>
-<dt>rdfs:range</dt>
-<dd>log:N3Document</dd>
 <dt>vs:term_status</dt>
-<dd>deprecated</dd>
+<dd class='term_status'>
+deprecated
+</dd>
+<dt>skos:note</dt>
+<dd class='note'>
+<p>For example, there may be a definitive document for the zipcode of
+airports by airport code, and so on. This is useful to let a reasoner
+know that it can extend its query to the given document.</p>
+
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>(Cwm will do this if its mode includes &quot;r&quot;).</p>
+
+</dd>
+<dt>rdfs:domain</dt>
+<dd class='domain'>
+rdf:Property
+</dd>
+<dt>rdfs:range</dt>
+<dd class='range'>
+log:N3Document
+</dd>
 </dl>
 </dd>
 <dt id='log_definitiveService'>
@@ -249,10 +352,27 @@ For mysql protocol, the URI of the service is like
 <code>sql://user:password@host.domain/database/</code>.</p>
 
 <dl class='annotations'>
-<dt>rdfs:domain</dt>
-<dd>rdf:Property</dd>
 <dt>vs:term_status</dt>
-<dd>deprecated</dd>
+<dd class='term_status'>
+deprecated
+</dd>
+<dt>skos:note</dt>
+<dd class='note'>
+<p>For example, there may be a definitive service for the zipcode of
+airports by airport code, and so on. This is useful to let a reasoner
+know that it can help resolve a query by delegating it to the service
+in question.</p>
+
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>(Cwm will do this if its mode includes &quot;r&quot;).</p>
+
+</dd>
+<dt>rdfs:domain</dt>
+<dd class='domain'>
+rdf:Property
+</dd>
 </dl>
 </dd>
 <dt id='log_dtlit'>
@@ -264,12 +384,23 @@ For mysql protocol, the URI of the service is like
 <p>Takes a list of a string and a URI and creates a datatyped literal.</p>
 
 <dl class='annotations'>
-<dt>rdfs:domain</dt>
-<dd>log:List</dd>
-<dt>rdfs:range</dt>
-<dd>rdfs:Literal</dd>
 <dt>vs:term_status</dt>
-<dd>deprecated</dd>
+<dd class='term_status'>
+deprecated
+</dd>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre>`{ ("2005-03-30T11:00:00" :tz) log:dtlit ?X } => { ?X a :Answer } .`
+will produce `"2005-03-30T11:00:00"^^:tz a :Answer .`</pre>
+</dd>
+<dt>rdfs:domain</dt>
+<dd class='domain'>
+log:List
+</dd>
+<dt>rdfs:range</dt>
+<dd class='range'>
+rdfs:Literal
+</dd>
 </dl>
 </dd>
 <dt id='log_equalTo'>
@@ -280,6 +411,22 @@ For mysql protocol, the URI of the service is like
 <dd>
 <p>True if the subject and object are the same RDF node (symbol or literal).</p>
 
+<dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:note</dt>
+<dd class='note'>
+<p>Do not confuse with owl:sameAs.</p>
+
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>A cwm built-in logical operator, RDF graph level.</p>
+
+</dd>
+</dl>
 </dd>
 <dt id='log_findall'>
 <strong>log:findall</strong>
@@ -292,12 +439,18 @@ Within the subject <code>?SCOPE</code> it unifies <code>?ANSWER</code> with a li
 all the instantiations of <code>?SELECT</code> satisfying the <code>?WHERE</code> clause.</p>
 
 <dl class='annotations'>
-<dt>rdfs:domain</dt>
-<dd>log:Formula</dd>
-<dt>rdfs:range</dt>
-<dd>log:List</dd>
 <dt>vs:term_status</dt>
-<dd>unstable</dd>
+<dd class='term_status'>
+unstable
+</dd>
+<dt>rdfs:domain</dt>
+<dd class='domain'>
+log:Formula
+</dd>
+<dt>rdfs:range</dt>
+<dd class='range'>
+log:List
+</dd>
 </dl>
 </dd>
 <dt id='log_forAllIn'>
@@ -310,7 +463,9 @@ all the instantiations of <code>?SELECT</code> satisfying the <code>?WHERE</code
 
 <dl class='annotations'>
 <dt>vs:term_status</dt>
-<dd>unstable</dd>
+<dd class='term_status'>
+unstable
+</dd>
 </dl>
 </dd>
 <dt id='log_forAllInClosure'>
@@ -323,7 +478,9 @@ all the instantiations of <code>?SELECT</code> satisfying the <code>?WHERE</code
 
 <dl class='annotations'>
 <dt>vs:term_status</dt>
-<dd>unstable</dd>
+<dd class='term_status'>
+unstable
+</dd>
 </dl>
 </dd>
 <dt id='log_implies'>
@@ -342,10 +499,26 @@ then the result of applying that same substitution to the
 conclusion may be added to the knowledge-base.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>related: See log:conclusion. 
+(See the CWM manual for command line options to determine how
+rules from different sources are applied to and the results
+added to various formula.)</p>
+
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:Formula</dd>
+<dd class='domain'>
+log:Formula
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:Formula</dd>
+<dd class='range'>
+log:Formula
+</dd>
 </dl>
 </dd>
 <dt id='log_includes'>
@@ -356,19 +529,33 @@ conclusion may be added to the knowledge-base.</p>
 <dd>
 <p>The subject formula includes the object formula.
 Formula A includes formula B if there exists some substitution
-which when applied to B creates a formula B' such that for
-every statement in B' is also in A, every variable
-universally (or existentially) quantified in B' is quantified in
-the same way in A.</p>
+which when applied to B creates a formula B&#39; such that for
+every statement in B&#39; is also in A, every variable
+universally (or existentially) quantified in B&#39; is quantified in
+the same way in A. </p>
 
 <p>Variable substitution is applied recursively to nested compound terms such as
 formulae, lists and sets.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>(Understood natively by cwm when in in the antecedent of a rule.
+You can use this to peer inside nested formulae.)</p>
+
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:Formula</dd>
+<dd class='domain'>
+log:Formula
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:Formula</dd>
+<dd class='range'>
+log:Formula
+</dd>
 </dl>
 </dd>
 <dt id='log_n3String'>
@@ -380,10 +567,18 @@ formulae, lists and sets.</p>
 <p>The subject formula, expressed as N3, gives this string.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:Formula</dd>
+<dd class='domain'>
+log:Formula
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:N3</dd>
+<dd class='range'>
+log:N3
+</dd>
 </dl>
 </dd>
 <dt id='log_notEqualTo'>
@@ -396,7 +591,18 @@ formulae, lists and sets.</p>
 
 <dl class='annotations'>
 <dt>owl:inverse</dt>
-<dd>log:equalTo</dd>
+<dd class='inverse'>
+log:equalTo
+</dd>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>A cwm built-in logical operator.</p>
+
+</dd>
 </dl>
 </dd>
 <dt id='log_notIn'>
@@ -409,7 +615,9 @@ formulae, lists and sets.</p>
 
 <dl class='annotations'>
 <dt>vs:term_status</dt>
-<dd>unstable</dd>
+<dd class='term_status'>
+unstable
+</dd>
 </dl>
 </dd>
 <dt id='log_notInClosure'>
@@ -422,7 +630,9 @@ formulae, lists and sets.</p>
 
 <dl class='annotations'>
 <dt>vs:term_status</dt>
-<dd>unstable</dd>
+<dd class='term_status'>
+unstable
+</dd>
 </dl>
 </dd>
 <dt id='log_notIncludes'>
@@ -436,10 +646,28 @@ True iff log:includes is false.
 The converse of log:includes.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>(Understood natively by cwm.
+The subject formula may contain variables.
+(In cwm, variables must of course end up getting bound
+before the log:include test can be done, or an infinite result set
+would result)
+Related: See includes</p>
+
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:Formula</dd>
+<dd class='domain'>
+log:Formula
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:Formula</dd>
+<dd class='range'>
+log:Formula
+</dd>
 </dl>
 </dd>
 <dt id='log_outputString'>
@@ -452,10 +680,19 @@ The converse of log:includes.</p>
 where the strings are to be output in the order of the keys.</p>
 
 <dl class='annotations'>
-<dt>rdfs:range</dt>
-<dd>log:String</dd>
 <dt>vs:term_status</dt>
-<dd>deprecated</dd>
+<dd class='term_status'>
+deprecated
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>See cwm --strings in cwm --help.</p>
+
+</dd>
+<dt>rdfs:range</dt>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='log_parsedAsN3'>
@@ -467,10 +704,18 @@ where the strings are to be output in the order of the keys.</p>
 <p>The subject string, parsed as N3, gives this formula.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:N3</dd>
+<dd class='domain'>
+log:N3
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:Formula</dd>
+<dd class='range'>
+log:Formula
+</dd>
 </dl>
 </dd>
 <dt id='log_racine'>
@@ -493,8 +738,19 @@ For anything else, it is itself.</p>
 <p>This is a low-level language type, one of log:Formula, log:Literal, log:List, log:Set or log:Other.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:note</dt>
+<dd class='note'>
+<p>log:semanticsOrError returns either a formula or a string, and you can check which using log:rawType.</p>
+
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:Type</dd>
+<dd class='range'>
+log:Type
+</dd>
 </dl>
 </dd>
 <dt id='log_rawUri'>
@@ -506,8 +762,19 @@ For anything else, it is itself.</p>
 <p>This allows one to look at the actual string of the URI which identifies this, for anything, even a blank node or a formula.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>This peeks into the internal workings of cwm, and so is not normally used. Use log:uri instead.</p>
+
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='log_semantics'>
@@ -526,16 +793,24 @@ appropriate specification to yield an RDF formula
 Evaluates to false if an unrecognized document format is retrieved.</p>
 
 <p>[Aside: Philosophers will be distracted here into worrying about the meaning
-of meaning. At least we didn't call this function "meaning"!
+of meaning. At least we didn&#39;t call this function &quot;meaning&quot;!
 In as much as N3 is used as an interlingua for interoperability
 for different systems, this for an N3 based system is the meaning 
 expressed by a document.]</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:N3Document</dd>
+<dd class='domain'>
+log:N3Document
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:Formula</dd>
+<dd class='range'>
+log:Formula
+</dd>
 </dl>
 </dd>
 <dt id='log_semanticsOrError'>
@@ -548,8 +823,15 @@ expressed by a document.]</p>
 or an error message explaining what went wrong with trying. See log:semantics.</p>
 
 <dl class='annotations'>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>(Cwm knows how to go get a document and parse it in order to evaluate this.)</p>
+
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:N3Document</dd>
+<dd class='domain'>
+log:N3Document
+</dd>
 </dl>
 </dd>
 <dt id='log_skolem'>
@@ -561,12 +843,18 @@ or an error message explaining what went wrong with trying. See log:semantics.</
 <p>Built-in to generate a Skolem IRI object which is a function of the arguments in the subject list</p>
 
 <dl class='annotations'>
-<dt>rdfs:domain</dt>
-<dd>log:List</dd>
-<dt>rdfs:range</dt>
-<dd>log:String</dd>
 <dt>vs:term_status</dt>
-<dd>unstable</dd>
+<dd class='term_status'>
+unstable
+</dd>
+<dt>rdfs:domain</dt>
+<dd class='domain'>
+log:List
+</dd>
+<dt>rdfs:range</dt>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='log_uri'>
@@ -578,8 +866,26 @@ or an error message explaining what went wrong with trying. See log:semantics.</
 <p>This allows one to look at the actual string of the URI which identifies this.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:note</dt>
+<dd class='note'>
+<p>This is a level breaker, breaking the rule of not looking inside a
+URI.   Use (eg with  string:match) to replace RDF&#39;s old &quot;aboutEach&quot;
+functionality. Use to implement the URI spec and protocol specs, etc.</p>
+
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>(Cwm can get the URI of a resource or get the resource from the URI.)</p>
+
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 </dl>
@@ -598,10 +904,14 @@ log:N3 is an instance of rdfs:Datatype and a subclass of rdfs:Literal.
 The value of log:content of a log:N3Document is a literal with datatype log:N3.</p>
 
 <dl class='annotations'>
-<dt>rdfs:subClassOf</dt>
-<dd>rdfs:Literal</dd>
 <dt>vs:term_status</dt>
-<dd>unstable</dd>
+<dd class='term_status'>
+unstable
+</dd>
+<dt>rdfs:subClassOf</dt>
+<dd class='subClassOf'>
+rdfs:Literal
+</dd>
 </dl>
 </dd>
 </dl>

--- a/ns/math.html
+++ b/ns/math.html
@@ -23,6 +23,10 @@
   }
   table.rdfs-definition td {vertical-align: top;}
   .bold {font-weight: bold;}
+  .note, .historyNote, .editorialNote {
+    margin-left: 2em;
+    font-style: italic;
+  }
 </style>
 </head>
 <body>
@@ -36,6 +40,15 @@
 <p>This is an ontology for computable math functions.</p>
 
 <p>The vocabulary is published by the <a href="https://www.w3.org/community/n3-dev/">W3C Notation-3 Community Group</a>.</p>
+
+</div>
+<div class='historyNote'>
+<h2>
+Historical Note
+</h2>
+<p>Schema for CWM&#39;s mathematical built-ins, SBP 2001-12</p>
+
+<p>$Id: math.n3,v 1.12 2010-03-30 15:18:08 timbl Exp $</p>
 
 </div>
 <section>
@@ -53,7 +66,9 @@
 
 <dl class='annotations'>
 <dt>rdfs:subClassOf</dt>
-<dd>owl:FunctionalProperty</dd>
+<dd class='subClassOf'>
+owl:FunctionalProperty
+</dd>
 </dl>
 </dd>
 <dt id='math_List'>
@@ -67,7 +82,9 @@ members are math:Value items.</p>
 
 <dl class='annotations'>
 <dt>rdfs:subClassOf</dt>
-<dd>log:List</dd>
+<dd class='subClassOf'>
+log:List
+</dd>
 </dl>
 </dd>
 <dt id='math_LogicalOperator'>
@@ -81,7 +98,9 @@ between two values</p>
 
 <dl class='annotations'>
 <dt>rdfs:subClassOf</dt>
-<dd>math:ReverseFunction, math:Function</dd>
+<dd class='subClassOf'>
+math:ReverseFunction, math:Function
+</dd>
 </dl>
 </dd>
 <dt id='math_ReverseFunction'>
@@ -94,7 +113,9 @@ between two values</p>
 
 <dl class='annotations'>
 <dt>rdfs:subClassOf</dt>
-<dd>owl:InverseFunctionalProperty</dd>
+<dd class='subClassOf'>
+owl:InverseFunctionalProperty
+</dd>
 </dl>
 </dd>
 <dt id='math_StrictProperty'>
@@ -107,7 +128,9 @@ between two values</p>
 
 <dl class='annotations'>
 <dt>rdfs:subClassOf</dt>
-<dd>rdf:Property</dd>
+<dd class='subClassOf'>
+rdf:Property
+</dd>
 </dl>
 </dd>
 <dt id='math_TwoMemberedList'>
@@ -120,7 +143,9 @@ between two values</p>
 
 <dl class='annotations'>
 <dt>rdfs:subClassOf</dt>
-<dd>math:List</dd>
+<dd class='subClassOf'>
+math:List
+</dd>
 </dl>
 </dd>
 <dt id='math_Value'>
@@ -133,7 +158,9 @@ between two values</p>
 
 <dl class='annotations'>
 <dt>rdfs:subClassOf</dt>
-<dd>_:g5540</dd>
+<dd class='subClassOf'>
+_:g5540
+</dd>
 </dl>
 </dd>
 </dl>
@@ -150,10 +177,18 @@ between two values</p>
 <p>The object is calulated as the absolute value of the subject.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_cos'>
@@ -166,10 +201,18 @@ between two values</p>
 The object is calulated as the cosine value of the subject.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_cosh'>
@@ -182,10 +225,18 @@ The object is calulated as the cosine value of the subject.</p>
 The object is calulated as the #hyperbolic cosine value of the subject.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_degrees'>
@@ -198,10 +249,18 @@ The object is calulated as the #hyperbolic cosine value of the subject.</p>
 The object is calulated as the conversion in degrees of the value of the subject.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_difference'>
@@ -214,10 +273,18 @@ The object is calulated as the conversion in degrees of the value of the subject
 is calculated by subtracting the second number of the pair from the first.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:TwoMemberedList</dd>
+<dd class='domain'>
+math:TwoMemberedList
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_equalTo'>
@@ -227,12 +294,39 @@ is calculated by subtracting the second number of the pair from the first.</p>
 </dt>
 <dd>
 
-
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:note</dt>
+<dd class='note'>
+<p><strong>schema</strong>:
+<code>$a1 math:equalTo $a2</code></p>
+
+<p><strong>summary</strong>:
+checks equality of numbers</p>
+
+<p><strong>definition</strong>:
+<code>true</code> if and only if <code>$a1</code> is equal to <code>$a2</code>. 
+Requires both arguments to be either concrete numerals, or variables bound to a numeral.</p>
+
+<p><strong>literal domains</strong>:</p>
+
+<ul>
+<li><code>$a1</code>: <code>xs:decimal</code> (or its derived types), <code>xs:float</code>, or <code>xs:double</code>  (see note on type promotion, and casting from string)</li>
+<li><code>$a2</code>: <code>xs:decimal</code> (or its derived types), <code>xs:float</code>, or <code>xs:double</code>  (see note on type promotion, and casting from string)</li>
+</ul>
+
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_exponentiation'>
@@ -245,10 +339,18 @@ is calculated by subtracting the second number of the pair from the first.</p>
 is calculated by raising the first number of the power of the second.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:TwoMemberedList</dd>
+<dd class='domain'>
+math:TwoMemberedList
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_greaterThan'>
@@ -260,10 +362,18 @@ is calculated by raising the first number of the power of the second.</p>
 <p>True iff the subject is a number which is greater than the object.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_integerQuotient'>
@@ -276,10 +386,18 @@ is calculated by raising the first number of the power of the second.</p>
 is calculated by dividing the first number of the pair by the second, ignoring remainder.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:TwoMemberedList</dd>
+<dd class='domain'>
+math:TwoMemberedList
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_lessThan'>
@@ -291,10 +409,18 @@ is calculated by dividing the first number of the pair by the second, ignoring r
 <p>True iff the subject is a number which is LESS than a object.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_negation'>
@@ -306,10 +432,18 @@ is calculated by dividing the first number of the pair by the second, ignoring r
 <p>The subject or object is calculated to be the negation of the other.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_notEqualTo'>
@@ -321,10 +455,18 @@ is calculated by dividing the first number of the pair by the second, ignoring r
 <p>True iff the subject is a number which is NOT EQUAL to a object.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_notGreaterThan'>
@@ -336,10 +478,18 @@ is calculated by dividing the first number of the pair by the second, ignoring r
 <p>True iff the subject is a number which is NOT greater than the object.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_notLessThan'>
@@ -351,10 +501,18 @@ is calculated by dividing the first number of the pair by the second, ignoring r
 <p>True iff the subject is a number which is NOT LESS than a object.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_product'>
@@ -367,10 +525,18 @@ is calculated by dividing the first number of the pair by the second, ignoring r
 The object is calculated as the arithmentic product of those numbers.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:List</dd>
+<dd class='domain'>
+math:List
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_quotient'>
@@ -383,10 +549,18 @@ The object is calculated as the arithmentic product of those numbers.</p>
 is calculated by dividing the first number of the pair by the second.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:TwoMemberedList</dd>
+<dd class='domain'>
+math:TwoMemberedList
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_remainder'>
@@ -399,10 +573,18 @@ is calculated by dividing the first number of the pair by the second.</p>
 is calculated by dividing the first number of the pair by the second and taking the remainder.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:TwoMemberedList</dd>
+<dd class='domain'>
+math:TwoMemberedList
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_rounded'>
@@ -414,10 +596,18 @@ is calculated by dividing the first number of the pair by the second and taking 
 <p>The object is calulated as the subject rounded to the nearest integer.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_sin'>
@@ -430,10 +620,18 @@ is calculated by dividing the first number of the pair by the second and taking 
 The object is calulated as the sine value of the subject.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_sinh'>
@@ -446,10 +644,18 @@ The object is calulated as the sine value of the subject.</p>
 The object is calulated as the hyperbolic sine value of the subject.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_sum'>
@@ -459,12 +665,44 @@ The object is calulated as the hyperbolic sine value of the subject.</p>
 </dt>
 <dd>
 
-
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:note</dt>
+<dd class='note'>
+<p><strong>schema</strong>:
+<code>($a_1 .. $a_n) math:sum $a_s</code></p>
+
+<p><strong>summary</strong>:
+performs addition of numbers</p>
+
+<p><strong>definition</strong>:
+<code>true</code> if and only if the arithmetic sum of <code>$a_1, .. $a_n</code> equals <code>$a_s</code>.
+Requires either:</p>
+
+<ol>
+<li>all <code>$a_1, .., $a_n</code> to be bound; or</li>
+<li>all but one <code>$a_i</code> (subject list) to be bound, and <code>$a_s</code> to be bound.</li>
+</ol>
+
+<p><strong>literal domains</strong>:</p>
+
+<ul>
+<li><code>$a_1 .. $a_n</code> : <code>xs:decimal</code> (or its derived types), <code>xs:float</code>, or <code>xs:double</code> (see note on type promotion, and casting from string)</li>
+<li><code>$a_s</code>: <code>xs:decimal</code> (or its derived types), <code>xs:float</code>, or <code>xs:double</code> (see note on type promotion, and casting from string)</li>
+</ul>
+
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:List</dd>
+<dd class='domain'>
+log:List
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_tan'>
@@ -477,10 +715,18 @@ The object is calulated as the hyperbolic sine value of the subject.</p>
 The object is calulated as the tangent value of the subject.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 <dt id='math_tanh'>
@@ -493,10 +739,18 @@ The object is calulated as the tangent value of the subject.</p>
 The object is calulated as the hyperbolic tangent value of the subject.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>math:Value</dd>
+<dd class='domain'>
+math:Value
+</dd>
 <dt>rdfs:range</dt>
-<dd>math:Value</dd>
+<dd class='range'>
+math:Value
+</dd>
 </dl>
 </dd>
 </dl>

--- a/ns/string.html
+++ b/ns/string.html
@@ -23,6 +23,10 @@
   }
   table.rdfs-definition td {vertical-align: top;}
   .bold {font-weight: bold;}
+  .note, .historyNote, .editorialNote {
+    margin-left: 2em;
+    font-style: italic;
+  }
 </style>
 </head>
 <body>
@@ -39,6 +43,13 @@ It is implemented, for example, in CWM and Euler.</p>
 <p>The vocabulary is published by the <a href="https://www.w3.org/community/n3-dev/">W3C Notation-3 Community Group</a>.</p>
 
 </div>
+<div class='historyNote'>
+<h2>
+Historical Note
+</h2>
+<p>Schema for string built-in functions in cwm.</p>
+
+</div>
 <section>
 <h2>Vocabulary Terms</h2>
 <section>
@@ -53,10 +64,18 @@ It is implemented, for example, in CWM and Euler.</p>
 <p>True iff the subject string contains the object string.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:String</dd>
+<dd class='domain'>
+log:String
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='string_containsIgnoringCase'>
@@ -70,10 +89,18 @@ with the comparison done ignoring the difference between upper case and
 lower case characters.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:String</dd>
+<dd class='domain'>
+log:String
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='string_endsWith'>
@@ -85,10 +112,18 @@ lower case characters.</p>
 <p>True iff the subject string ends with the object string.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:String</dd>
+<dd class='domain'>
+log:String
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='string_equalIgnoringCase'>
@@ -101,10 +136,18 @@ lower case characters.</p>
 ignoring differences between upper and lower case.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:String</dd>
+<dd class='domain'>
+log:String
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='string_greaterThan'>
@@ -116,10 +159,18 @@ ignoring differences between upper and lower case.</p>
 <p>True iff the string is greater than the object when ordered according to Unicode(tm) code order.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:String</dd>
+<dd class='domain'>
+log:String
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='string_lessThan'>
@@ -131,10 +182,18 @@ ignoring differences between upper and lower case.</p>
 <p>True iff the string is less than the object when ordered according to Unicode(tm) code order.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:String</dd>
+<dd class='domain'>
+log:String
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='string_matches'>
@@ -148,10 +207,18 @@ the object is is a regular expression in the perl, python style.
 It is true iff the string matches the regexp.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:String</dd>
+<dd class='domain'>
+log:String
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='string_notEqualIgnoringCase'>
@@ -164,10 +231,18 @@ It is true iff the string matches the regexp.</p>
 ignoring differences between upper and lower case.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:String</dd>
+<dd class='domain'>
+log:String
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='string_notGreaterThan'>
@@ -179,10 +254,18 @@ ignoring differences between upper and lower case.</p>
 <p>True iff the string is NOT greater than the object when ordered according to Unicode(tm) code order.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:String</dd>
+<dd class='domain'>
+log:String
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='string_notLessThan'>
@@ -194,10 +277,18 @@ ignoring differences between upper and lower case.</p>
 <p>True iff the string is NOT less than the object when ordered according to Unicode(tm) code order.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:String</dd>
+<dd class='domain'>
+log:String
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='string_notMatches'>
@@ -211,10 +302,18 @@ the object is is a regular expression in the perl, python style.
 It is true iff the string does NOT match the regexp.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:String</dd>
+<dd class='domain'>
+log:String
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='string_replace'>
@@ -229,10 +328,18 @@ input data, the second the old and the third the new string.
 The object is calculated as the replaced string.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre>("fofof bar", "of", "baz") string:replace "fbazbaz bar"</pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:List</dd>
+<dd class='domain'>
+log:List
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='string_scrape'>
@@ -248,10 +355,18 @@ the regular expression, then the object is calculated as being the
 part of the first string which matches the group.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:List</dd>
+<dd class='domain'>
+log:List
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 <dt id='string_startsWith'>
@@ -263,10 +378,18 @@ part of the first string which matches the group.</p>
 <p>True iff the subject string starts with the object string.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>log:String</dd>
+<dd class='domain'>
+log:String
+</dd>
 <dt>rdfs:range</dt>
-<dd>log:String</dd>
+<dd class='range'>
+log:String
+</dd>
 </dl>
 </dd>
 </dl>

--- a/ns/time.html
+++ b/ns/time.html
@@ -23,6 +23,10 @@
   }
   table.rdfs-definition td {vertical-align: top;}
   .bold {font-weight: bold;}
+  .note, .historyNote, .editorialNote {
+    margin-left: 2em;
+    font-style: italic;
+  }
 </style>
 </head>
 <body>
@@ -36,6 +40,22 @@
 <p>Based on orginal cwm_date and cwm_time by Mark Nottingham</p>
 
 <p>The vocabulary is published by the <a href="https://www.w3.org/community/n3-dev/">W3C Notation-3 Community Group</a>.</p>
+
+</div>
+<div class='historyNote'>
+<h2>
+Historical Note
+</h2>
+<p>n3 definition of some time and date functions</p>
+
+<p>Based on orginal cwm<em>date and cwm</em>time by Mark Nottingham
+http://www.mnot.com/python
+These use isodate.py and timegm.py, by mnot.
+Released with permission under W3C code licence.</p>
+
+<p>Schema (c) TimBL, #C code licence.</p>
+
+<p>$Id: time.n3,v 1.7 2006-12-13 21:10:29 timbl Exp $</p>
 
 </div>
 <section>
@@ -53,10 +73,18 @@
 the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>xsd:dateTime</dd>
+<dd class='domain'>
+xsd:dateTime
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:integer</dd>
+<dd class='range'>
+xsd:integer
+</dd>
 </dl>
 </dd>
 <dt id='time_dayOfWeek'>
@@ -69,10 +97,18 @@ the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>xsd:dateTime</dd>
+<dd class='domain'>
+xsd:dateTime
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:integer</dd>
+<dd class='range'>
+xsd:integer
+</dd>
 </dl>
 </dd>
 <dt id='time_gmTime'>
@@ -85,16 +121,24 @@ the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 result of formatting the Universal Time of processing in the format given.
 If the format string has zero length,
 then the ISOdate standard format is used. 
-<code>[ is time:gmtime of ""]</code>  the therefore the current date time.
-It will end with "Z" as a timezone code.
+<code>[ is time:gmtime of &quot;&quot;]</code>  the therefore the current date time.
+It will end with &quot;Z&quot; as a timezone code.
 the <em>object</em> can be calculated as a function of the <em>subject</em>.
 Rules which use this function will of course NOT be repeatable.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>time:format</dd>
+<dd class='domain'>
+time:format
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:string</dd>
+<dd class='range'>
+xsd:string
+</dd>
 </dl>
 </dd>
 <dt id='time_hour'>
@@ -107,10 +151,18 @@ Rules which use this function will of course NOT be repeatable.</p>
 the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>xsd:dateTime</dd>
+<dd class='domain'>
+xsd:dateTime
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:integer</dd>
+<dd class='range'>
+xsd:integer
+</dd>
 </dl>
 </dd>
 <dt id='time_inSeconds'>
@@ -120,14 +172,28 @@ the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 </dt>
 <dd>
 <p>Iff the <em>subject</em> is a <code>xsd:dateTime</code> and the <em>object</em> is the integer number of seconds
-since the beginning of the era on a given system.  Don't assume a particular value, always test for it.
+since the beginning of the era on a given system.  Don&#39;t assume a particular value, always test for it.
 the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
+<dt>skos:editorialNote</dt>
+<dd class='editorialNote'>
+<p>Cwm implements this as a bidirectional function: you can calculate the
+ISO date from the seconds since the beginning of the era, or vice-versa.</p>
+
+</dd>
 <dt>rdfs:domain</dt>
-<dd>xsd:dateTime</dd>
+<dd class='domain'>
+xsd:dateTime
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:integer</dd>
+<dd class='range'>
+xsd:integer
+</dd>
 </dl>
 </dd>
 <dt id='time_localTime'>
@@ -140,16 +206,24 @@ the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 result of formatting the current time of processing and local timezone in the format given.
 If the format string has zero length,
 then the ISOdate standard format is used. 
-<code>[ is time:gmtime of ""]</code>  the therefore the current date time.
-It will end with "Z" as a timezone code.
+<code>[ is time:gmtime of &quot;&quot;]</code>  the therefore the current date time.
+It will end with &quot;Z&quot; as a timezone code.
 the <em>object</em> can be calculated as a function of the <em>subject</em>.
 Rules which use this function will of course NOT be repeatable.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>time:format</dd>
+<dd class='domain'>
+time:format
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:string</dd>
+<dd class='range'>
+xsd:string
+</dd>
 </dl>
 </dd>
 <dt id='time_minute'>
@@ -162,10 +236,18 @@ Rules which use this function will of course NOT be repeatable.</p>
 the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>xsd:dateTime</dd>
+<dd class='domain'>
+xsd:dateTime
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:integer</dd>
+<dd class='range'>
+xsd:integer
+</dd>
 </dl>
 </dd>
 <dt id='time_month'>
@@ -178,10 +260,18 @@ the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>xsd:dateTime</dd>
+<dd class='domain'>
+xsd:dateTime
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:integer</dd>
+<dd class='range'>
+xsd:integer
+</dd>
 </dl>
 </dd>
 <dt id='time_second'>
@@ -194,10 +284,18 @@ the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>xsd:dateTime</dd>
+<dd class='domain'>
+xsd:dateTime
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:integer</dd>
+<dd class='range'>
+xsd:integer
+</dd>
 </dl>
 </dd>
 <dt id='time_timeZone'>
@@ -207,14 +305,22 @@ the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 </dt>
 <dd>
 <p>Iff the <em>subject</em> is a <code>xsd:dateTime</code> and the <em>object</em> is the trailing timezone offset
-part, e.g.  "-05:00"..
+part, e.g.  &quot;-05:00&quot;..
 the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>xsd:dateTime</dd>
+<dd class='domain'>
+xsd:dateTime
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:string</dd>
+<dd class='range'>
+xsd:string
+</dd>
 </dl>
 </dd>
 <dt id='time_year'>
@@ -227,10 +333,18 @@ the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 the <em>object</em> can be calculated as a function of the <em>subject</em>.</p>
 
 <dl class='annotations'>
+<dt>skos:example</dt>
+<dd class='example'>
+<pre></pre>
+</dd>
 <dt>rdfs:domain</dt>
-<dd>xsd:dateTime</dd>
+<dd class='domain'>
+xsd:dateTime
+</dd>
 <dt>rdfs:range</dt>
-<dd>xsd:integer</dd>
+<dd class='range'>
+xsd:integer
+</dd>
 </dl>
 </dd>
 </dl>

--- a/ns/vocab_context.jsonld
+++ b/ns/vocab_context.jsonld
@@ -1,12 +1,14 @@
 {
   "@context": {
     "dc": "http://purl.org/dc/elements/1.1/",
+    "cc": "http://creativecommons.org/ns#",
+    "owl": "http://www.w3.org/2002/07/owl#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "rdft": "http://www.w3.org/ns/rdftest#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "owl": "http://www.w3.org/2002/07/owl#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
     "vs": "http://www.w3.org/2003/06/sw-vocab-status/ns#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
 
     "cr": "http://www.w3.org/2000/10/swap/crypto#",
     "list": "http://www.w3.org/2000/10/swap/list#",

--- a/ns/vocab_template.haml
+++ b/ns/vocab_template.haml
@@ -23,6 +23,10 @@
       }
       table.rdfs-definition td {vertical-align: top;}
       .bold {font-weight: bold;}
+      .note, .historyNote, .editorialNote {
+        margin-left: 2em;
+        font-style: italic;
+      }
   %body
     %p
       %a{href: "http://www.w3.org/"}
@@ -33,6 +37,13 @@
         #{ontology["rdfs:comment"]}
 
         The vocabulary is published by the [W3C Notation-3 Community Group](https://www.w3.org/community/n3-dev/).
+    - %w(note historyNote editorialNote).each do |cls|
+      -if ontology["skos:#{cls}"]
+        %div{class: cls}
+          %h2
+            = {note: "Notes", historyNote: "Historical Note", editorialNote: "Editorial Notes"}[cls.to_sym]
+          :markdown
+            #{ontology["skos:#{cls}"]}
     - if ontology["rdfs:seeAlso"]
       %strong
         See Also:
@@ -48,6 +59,8 @@
          { heading: "Property Definitions",  values: Array(properties)},
          { heading: "Datatype Definitions",  values: Array(datatypes)},
         ]
+        example_props = %(skos:example)
+        markdown_props = %(rdfs:comment dc:description skos:note skos:historyNote skos:editorialNote)
       - sect_defs.each do |sect|
         - next if sect[:values].empty?
         %section
@@ -62,12 +75,20 @@
               %dd
                 :markdown
                   #{defn["rdfs:comment"]}
-                - if %w(rdfs:subClassOf rdfs:subPropertyOf rdfs:domain rdfs:range vs:term_status owl:inverse).any? { |p| defn.has_key?(p)}
+                - if %w(owl:inverse vs:term_status skos:note skos:historyNote skos:editorialNote rdfs:subClassOf rdfs:subPropertyOf rdfs:domain rdfs:range).any? { |p| defn.has_key?(p)}
                   %dl{class: :annotations}
-                    - %w(rdfs:subClassOf rdfs:subPropertyOf rdfs:domain rdfs:range vs:term_status owl:inverse).each do |p|
+                    - %w(owl:inverse vs:term_status skos:example skos:note skos:historyNote skos:editorialNote rdfs:subClassOf rdfs:subPropertyOf rdfs:domain rdfs:range).each do |p|
                       - if defn.has_key?(p)
                         %dt<=p
-                        %dd<= Array(defn[p]).join(", ")
+                        %dd{class: p.split(':').last}
+                          - if markdown_props.include?(p)
+                            :markdown
+                              #{Array(defn[p]).join(", ")}
+                          - elsif example_props.include?(p)
+                            %pre
+                              = Array(defn[p]).join(", ")
+                          - else
+                            = Array(defn[p]).join(", ")
     %footer
       :markdown
         All vocabularies are licensed by contributors under the


### PR DESCRIPTION
This shows everything, and gives it a class based on the property. You should be able to affect styling by updating the `:css` section of vocab_template.haml and running `rake`. (Although, you'll probably need to install some gems it complains about needing). You can `display: none` class you don't want to show up.